### PR TITLE
support for working with translations

### DIFF
--- a/src/Plugin/Action/StateChange.php
+++ b/src/Plugin/Action/StateChange.php
@@ -94,7 +94,11 @@ class StateChange extends ActionBase implements ContainerFactoryPluginInterface 
    * @return \Drupal\Core\Entity\ContentEntityInterface
    */
   protected function loadLatestRevision(ContentEntityInterface $entity) {
-    return $this->moderationInfo->getLatestRevision($entity->getEntityTypeId(), $entity->id());
+    $original_entity = $this->moderationInfo->getLatestRevision($entity->getEntityTypeId(), $entity->id());
+    if (!$entity->isDefaultTranslation() && $original_entity->hasTranslation($entity->language()->getId())) {
+      $original_entity = $original_entity->getTranslation($entity->language()->getId());
+    }
+    return $original_entity;
   }
 
   /**


### PR DESCRIPTION
If you try to change the state of a non-default-language entity, it doesn't work, because loadLatestRevision ignores the language.

This update seems to fix that..